### PR TITLE
Cleanup of log entries and other adjustments

### DIFF
--- a/TWShockLink/API/ShockLinkAPI.cs
+++ b/TWShockLink/API/ShockLinkAPI.cs
@@ -9,32 +9,38 @@ namespace ShockLink.Integrations.TW.API;
 internal static class ShockLinkAPI
 {
     private static HttpClient? _client;
-    private static readonly MelonLogger.Instance Logger = new("ShockLink.Integrations.TW", Color.LawnGreen);
 
     public static void Reload(string endpoint, string token)
     {
         if (string.IsNullOrWhiteSpace(token))
         {
-            Logger.Msg("No ApiToken Configured");
+            ShockLinkIntegrationTW.Logger.Error("No ApiToken Configured");
             return;
         }
         if (string.IsNullOrWhiteSpace(endpoint))
         {
-            Logger.Msg("No Endpoint Configured");
+            ShockLinkIntegrationTW.Logger.Error("No Endpoint Configured");
             return;
         }
 
-        _client = new();
-        _client.BaseAddress = new Uri(endpoint);
-        _client.DefaultRequestHeaders.Add("ShockLinkToken", token);
-        Logger.Msg("Setup Client");
+        try
+        {
+            _client = new();
+            _client.BaseAddress = new Uri(endpoint);
+            _client.DefaultRequestHeaders.Add("ShockLinkToken", token);
+            ShockLinkIntegrationTW.Logger.Msg("Setup ShockLink API Client");
+        }
+        catch (UriFormatException e)
+        {
+            ShockLinkIntegrationTW.Logger.Error("The Base API URL entered is not a valid URL! Please check your settings!");
+        }
     }
 
     public static async Task Control(params Control[] data)
     {
         if (_client == null)
         {
-            Logger.Msg("No ApiToken or Endpoint configured");
+            ShockLinkIntegrationTW.Logger.Error("No ApiToken or Endpoint configured");
             return;
         }
         try
@@ -46,14 +52,14 @@ internal static class ShockLinkAPI
             var result = await _client.SendAsync(message);
             if (!result.IsSuccessStatusCode)
             {
-                Logger.Error(result.StatusCode);
-                Logger.Error(await result.Content.ReadAsStringAsync());
+                ShockLinkIntegrationTW.Logger.Error(result.StatusCode);
+                ShockLinkIntegrationTW.Logger.Error(await result.Content.ReadAsStringAsync());
             }
 
         }
         catch (Exception ex)
         {
-            Logger.Error("Send failed", ex);
+            ShockLinkIntegrationTW.Logger.Error("Send failed", ex);
             throw;
         }
     }
@@ -62,13 +68,13 @@ internal static class ShockLinkAPI
     {
         if (_client == null)
         {
-            Logger.Msg("No ApiToken or Endpoint configured");
+            ShockLinkIntegrationTW.Logger.Error("No ApiToken or Endpoint configured");
             return null;
         }
         var response = await _client.GetAsync($"/1/shockers/{shockerId}");
         if (!response.IsSuccessStatusCode)
         {
-            Logger.Warning("Error while getting shocker info", shockerId, response.StatusCode, await response.Content.ReadAsStringAsync());
+            ShockLinkIntegrationTW.Logger.Warning("Error while getting shocker info", shockerId, response.StatusCode, await response.Content.ReadAsStringAsync());
             return null;
         }
         var content = await response.Content.ReadAsStringAsync();
@@ -80,19 +86,19 @@ internal static class ShockLinkAPI
     {
         if (_client == null)
         {
-            Logger.Msg("No ApiToken or Endpoint configured");
+            ShockLinkIntegrationTW.Logger.Error("No ApiToken or Endpoint configured");
             return null;
         }
         
         var response = await _client.GetAsync($"/1/shockers/{shockerId}/logs");
-        Logger.Msg(response.StatusCode);
+        ShockLinkIntegrationTW.Logger.Msg(response.StatusCode);
         if (!response.IsSuccessStatusCode)
         {
-            Logger.Warning("Error while getting shocker logs", shockerId, response.StatusCode, await response.Content.ReadAsStringAsync());
+            ShockLinkIntegrationTW.Logger.Warning("Error while getting shocker logs", shockerId, response.StatusCode, await response.Content.ReadAsStringAsync());
             return null;
         }
         var content = await response.Content.ReadAsStringAsync();
-        Logger.Msg(content);
+        ShockLinkIntegrationTW.Logger.Msg(content);
         var json = JsonConvert.DeserializeObject<BaseResponse<IEnumerable<LogEntry>>>(content);
         return json?.Data;
     }

--- a/TWShockLink/ShockLinkIntegrationTW.cs
+++ b/TWShockLink/ShockLinkIntegrationTW.cs
@@ -5,6 +5,8 @@ using ShockLink.Integrations.TW;
 using ShockLink.Integrations.TW.API;
 
 [assembly: MelonInfo(typeof(ShockLinkIntegrationTW), "ShockLink.Integrations.TW", "1.0.0", "ShockLink Team")]
+[assembly: MelonGame("Alpha Blend Interactive", "ChilloutVR")]
+[assembly: MelonOptionalDependencies("TotallyWholesome")]
 
 namespace ShockLink.Integrations.TW;
 
@@ -14,6 +16,8 @@ public class ShockLinkIntegrationTW : MelonMod
     internal static HarmonyLib.Harmony HarmonyInst;
     internal static MelonPreferences_Entry<int> IntensityLimit;
     internal static MelonPreferences_Entry<float> DurationLimit;
+    internal static MelonPreferences_Entry<string> APIToken;
+    internal static MelonPreferences_Entry<string> APIEndpoint;
 
     private const string DefaultBaseUri = "https://api.shocklink.net";
 
@@ -24,18 +28,18 @@ public class ShockLinkIntegrationTW : MelonMod
         Logger.Msg("Getting config options..");
         var category = MelonPreferences.CreateCategory("ShockLinkIntegrationsTW");
 
-        var tokenSetting = category.CreateEntry("APIToken", "");
-        var endPointSetting = category.CreateEntry("APIBaseUri", DefaultBaseUri);
+        APIToken = category.CreateEntry("APIToken", "", "ShockLink API Token", "Your generated API Token for ShockLink, you can get this from the website");
+        APIEndpoint = category.CreateEntry("APIBaseUri", DefaultBaseUri, "ShockLink API URL", "Base API URL for ShockLink");
 
         IntensityLimit = MelonPreferences.CreateEntry("ShockLinkIntegrationsTW", "IntensityLimit", 25, "Intensity Limit", "This sets the maximum intensity allowed for ShockLink operations");
         DurationLimit = MelonPreferences.CreateEntry("ShockLinkIntegrationsTW", "DurationLimit", 10f, "Duration Limit", "This sets the maximum duration allowed for ShockLink operations");
 
-        tokenSetting.OnEntryValueChanged.Subscribe(
-            (_, newValue) => ShockLinkAPI.Reload(endPointSetting.Value, newValue));
-        endPointSetting.OnEntryValueChanged.Subscribe(
-            (_, newValue) => ShockLinkAPI.Reload(newValue, tokenSetting.Value));
+        APIToken.OnEntryValueChanged.Subscribe(
+            (_, newValue) => ShockLinkAPI.Reload(APIEndpoint.Value, newValue));
+        APIEndpoint.OnEntryValueChanged.Subscribe(
+            (_, newValue) => ShockLinkAPI.Reload(newValue, APIToken.Value));
 
-        ShockLinkAPI.Reload(endPointSetting.Value, tokenSetting.Value);
+        ShockLinkAPI.Reload(APIEndpoint.Value, APIToken.Value);
         
         Logger.Msg("Waiting for TotallyWholesome to be loaded...");
     }

--- a/TWShockLink/TWPatches.cs
+++ b/TWShockLink/TWPatches.cs
@@ -14,7 +14,7 @@ public class TWPatches
 {
     public static void ApplyTWIntegration()
     {
-        ShockLinkIntegrationTW.Logger.Msg("Applying Patches");
+        ShockLinkIntegrationTW.Logger.Msg("Patching TotallyWholesome...");
 
         ApplyPatch(typeof(PiShockManager), "Execute",
             typeof(TWPatches), nameof(PatchExcecute));
@@ -28,14 +28,12 @@ public class TWPatches
         ApplyPatch(typeof(PiShockManager), "GetShockerInfo",
             typeof(TWPatches), nameof(PatchGetShockerInfo));
         
-        ShockLinkIntegrationTW.Logger.Msg("Finished applying Patches");
+        ShockLinkIntegrationTW.Logger.Msg("Successfully patched TotallyWholesome! ShockLink Integration ready!");
     }
     
     
     private static void ApplyPatch(Type originalClass, string originalMethod, Type patchType, string patchMethod)
     {
-        ShockLinkIntegrationTW.Logger.Msg($"Applying Patch {originalMethod}");
-
         try
         {
             var originalMethodInfo = originalClass.GetMethod(originalMethod,
@@ -47,8 +45,8 @@ public class TWPatches
         }
         catch (Exception ex)
         {
-            ShockLinkIntegrationTW.Logger.Error(ex);
             ShockLinkIntegrationTW.Logger.Error($"Failed to apply patch for {originalMethod}");
+            ShockLinkIntegrationTW.Logger.Error(ex);
         }
     }
     


### PR DESCRIPTION
Made log entries clearer, reduced log spam when starting patching, instead just showing when a patch completes. 
Removed unneeded MelonLogger instance in ShockLinkAPI.cs 
Added TotallyWholesome to MelonOptionalDependencies.
Added error checking to base API URL changes